### PR TITLE
Add iai benchmark (based on integration tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,8 +147,8 @@ checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "syn 1.0.100",
 ]
 
@@ -219,6 +219,7 @@ dependencies = [
  "bitvec",
  "cap",
  "hashbrown 0.13.1",
+ "iai-callgrind",
  "itertools",
  "log",
  "ndarray",
@@ -481,6 +482,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "iai-callgrind"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c91bf5ba682f8ac7eb23bf43ec2c4263bf7d4e6625e83c3bf94459800e18f73"
+dependencies = [
+ "bincode",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af5af66b85e350097b8c0f6329c6347d3323d010443475741c29a1a167f116fb"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "syn 2.0.38",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af62d1a0a82e7841719de6998e4f306f936143d0abbde8740c6677e57b75fd95"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,8 +773,8 @@ version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "syn 1.0.100",
 ]
 
@@ -770,8 +803,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "syn 1.0.100",
  "version_check",
 ]
@@ -782,8 +815,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "version_check",
 ]
 
@@ -798,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
 dependencies = [
  "unicode-ident",
 ]
@@ -822,11 +855,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.43",
+ "proc-macro2 1.0.68",
 ]
 
 [[package]]
@@ -955,8 +988,8 @@ version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "syn 1.0.100",
 ]
 
@@ -1077,8 +1110,19 @@ version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+dependencies = [
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -1126,8 +1170,8 @@ version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "syn 1.0.100",
 ]
 
@@ -1173,8 +1217,8 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
- "proc-macro2 1.0.43",
- "quote 1.0.21",
+ "proc-macro2 1.0.68",
+ "quote 1.0.33",
  "syn 1.0.100",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [workspace]
-
+resolver = "2"
 members = [
   "server",
   "dmslib",
   "dmscli",
 ]
+
+[profile.bench]
+# Include debug symbols in benchmarks
+debug = 2

--- a/dmslib/Cargo.toml
+++ b/dmslib/Cargo.toml
@@ -21,3 +21,10 @@ bincode = "1.3.3"
 default = ["hashbrown", "minmem"]
 hashbrown = ["dep:hashbrown"]
 minmem = []
+
+[dev-dependencies]
+iai-callgrind = "0.7.1"
+
+[[bench]]
+name = "pe0_demo_iai"
+harness = false

--- a/dmslib/benches/pe0_demo_iai.rs
+++ b/dmslib/benches/pe0_demo_iai.rs
@@ -1,0 +1,94 @@
+use iai_callgrind::{black_box, main, library_benchmark_group, library_benchmark};
+use dmslib::teams::*;
+use dmslib::teams::transitions::*;
+use dmslib::teams::state::*;
+use dmslib::policy::*;
+
+const SYSTEM_PAPER_EXAMPLE_0: &str = include_str!("../../graphs/FieldTeams/paperE0.json");
+
+// These are the same test cases from integration tests.
+
+fn setup_1_team() -> (Problem, Config) {
+    let input_graph: dmslib::io::Graph = serde_json::from_str(SYSTEM_PAPER_EXAMPLE_0).unwrap();
+    input_graph
+        .to_teams_problem(
+            vec![dmslib::io::Team {
+                index: Some(0),
+                latlng: None,
+            }],
+            Some(30),
+        )
+        .unwrap()
+}
+
+fn setup_2_team() -> (Problem, Config) {
+    use dmslib::io;
+    let input_graph: io::Graph = serde_json::from_str(SYSTEM_PAPER_EXAMPLE_0).unwrap();
+    input_graph
+        .to_teams_problem(
+            vec![
+                io::Team {
+                    index: Some(1),
+                    latlng: None,
+                },
+                io::Team {
+                    index: Some(6),
+                    latlng: None,
+                },
+            ],
+            Some(30),
+        )
+        .unwrap()
+}
+
+#[library_benchmark]
+#[bench::with_1_team(setup_1_team())]
+#[bench::with_2_teams(setup_2_team())]
+fn solve_naive(input: (Problem, Config)) {
+    let (problem, config) = input;
+    let solution = solve_generic::<
+        RegularTransition,
+        NaiveExplorer<RegularTransition, NaiveActions, NaiveStateIndexer>,
+        NaiveActionApplier,
+        NaivePolicySynthesizer,
+    >(&problem.graph, problem.initial_teams.clone(), &config)
+    .unwrap();
+    black_box(solution);
+}
+
+#[library_benchmark]
+#[bench::with_1_team(setup_1_team())]
+#[bench::with_2_teams(setup_2_team())]
+fn solve_naive_bitstack(input: (Problem, Config)) {
+    let (problem, config) = input;
+    let solution = solve_generic::<
+        RegularTransition,
+        NaiveExplorer<RegularTransition, NaiveActions, BitStackStateIndexer>,
+        NaiveActionApplier,
+        NaivePolicySynthesizer,
+    >(&problem.graph, problem.initial_teams.clone(), &config)
+    .unwrap();
+    black_box(solution);
+}
+
+#[library_benchmark]
+#[bench::with_1_team(setup_1_team())]
+#[bench::with_2_teams(setup_2_team())]
+fn solve_opt(input: (Problem, Config)) {
+    let (problem, config) = input;
+    let solution = solve_generic::<
+        TimedTransition,
+        NaiveExplorer<TimedTransition, FilterEnergizedOnWay<PermutationalActions>, SortedStateIndexer<BitStackStateIndexer>>,
+        TimedActionApplier<TimeUntilEnergization>,
+        NaiveTimedPolicySynthesizer,
+    >(&problem.graph, problem.initial_teams.clone(), &config)
+    .unwrap();
+    black_box(solution);
+}
+
+library_benchmark_group!(
+    name = bench_fibonacci_group;
+    benchmarks = solve_naive, solve_naive_bitstack, solve_opt
+);
+
+main!(library_benchmark_groups = bench_fibonacci_group);

--- a/dmslib/src/teams.rs
+++ b/dmslib/src/teams.rs
@@ -5,8 +5,8 @@ mod solve_variations;
 pub mod state;
 pub mod transitions;
 
-use actions::*;
-use exploration::*;
+pub use actions::*;
+pub use exploration::*;
 pub use solve_variations::*;
 use state::*;
 use transitions::*;
@@ -134,7 +134,7 @@ impl Default for Config {
     }
 }
 
-fn solve_generic<'a, TT, E, AA, PS>(
+pub fn solve_generic<'a, TT, E, AA, PS>(
     graph: &'a Graph,
     initial_teams: Vec<TeamState>,
     config: &Config,


### PR DESCRIPTION
Added a benchmark using [iai-callgrind](https://crates.io/crates/iai-callgrind) based on the `pe0` example in the integration tests.